### PR TITLE
Add context to settings edit screen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ git:
 
 matrix:
   include:
-    - python: "2.7"
-      env: TOXENV=py27
+    - python: "3.7"
+      env: TOXENV=py37
     - python: "3.5"
       env: TOXENV=py35
 

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -400,6 +400,18 @@ class ChannelView(View):
             fill=(255, 255, 255),
         )
 
+    def draw_context(self, position, metric="Hz"):
+        context = f"Now: {self.channel.sensor.moisture:.2f}Hz"
+        if metric.lower() == "sat":
+            context = f"Now: {self.channel.sensor.saturation * 100:.2f}%"
+
+        self._draw.text(
+            position,
+            context,
+            font=self.font,
+            fill=(255, 255, 255),
+        )
+
 
 class DetailView(ChannelView):
     """Single channel details.
@@ -507,6 +519,7 @@ class ChannelEditView(ChannelView, EditView):
                 "round": 2,
                 "format": lambda value: f"{value * 100:0.2f}%",
                 "help": "Saturation at which alarm is triggered",
+                "context": "sat",
             },
             {
                 "title": "Enabled",
@@ -525,6 +538,7 @@ class ChannelEditView(ChannelView, EditView):
                 "round": 2,
                 "format": lambda value: f"{value:0.2f}Hz",
                 "help": "Frequency for fully saturated soil",
+                "context": "hz",
             },
             {
                 "title": "Dry Point",
@@ -536,6 +550,7 @@ class ChannelEditView(ChannelView, EditView):
                 "round": 2,
                 "format": lambda value: f"{value:0.2f}Hz",
                 "help": "Frequency for fully dried soil",
+                "context": "hz",
             },
         ]
         EditView.__init__(self, image, options)
@@ -545,6 +560,10 @@ class ChannelEditView(ChannelView, EditView):
         self.clear()
 
         EditView.render(self)
+
+        option = self._options[self._current_option]
+        if "context" in option:
+            self.draw_context((34, 6), option["context"])
 
 
 class Channel:

--- a/library/.coveragerc
+++ b/library/.coveragerc
@@ -1,4 +1,4 @@
 [run]
-source = enviroplus
+source = grow
 omit =
     .tox/*

--- a/library/README.md
+++ b/library/README.md
@@ -57,6 +57,7 @@ You should read the following to get up and running with our monitoring script:
 * Discord - https://discord.gg/hr93ByC
 
 # Changelog
+
 0.0.1
 -----
 

--- a/library/grow/pump.py
+++ b/library/grow/pump.py
@@ -80,4 +80,3 @@ class Pump(object):
             self.set_speed(speed)
             self._timeout.start()
             return True
-

--- a/library/tests/test_setup.py
+++ b/library/tests/test_setup.py
@@ -1,56 +1,47 @@
+import mock
+
+
 def test_moisture_setup(GPIO, smbus):
-    from grow import moisture
-    moisture._is_setup = False
+    from grow.moisture import Moisture
 
-    moisture.setup()
-    moisture.setup()
+    ch1 = Moisture(channel=1)
+    ch2 = Moisture(channel=2)
+    ch3 = Moisture(channel=3)
 
-
-def test_moisture_read_all(GPIO, smbus):
-    from grow import moisture
-    moisture._is_setup = False
-
-    result = moisture.read_all()
-
-    assert type(result(1)) == float
-    assert int(result(1)) == 100
-
-    assert type(result(2)) == float
-    assert int(result(2)) == 500
-
-    assert type(result.(3)) == float
-    assert int(result.(3)) == 5000
-
-    assert "Moisture" in str(result)
+    assert GPIO.setup.has_calls([
+        mock.call(ch1._gpio_pin, GPIO.IN),
+        mock.call(ch2._gpio_pin, GPIO.IN),
+        mock.call(ch3._gpio_pin, GPIO.IN)
+    ])
 
 
-def test_moisture_read_each(GPIO, smbus):
-    from grow import moisture
-    moisture._is_setup = False
+def test_moisture_read(GPIO, smbus):
+    from grow.moisture import Moisture
 
-    assert int(moisture.read(1)) == 100
-    assert int(moisture.read(2)) == 500
-    assert int(moisture.read(3)) == 5000
+    assert Moisture(channel=1).saturation == 1.0
+    assert Moisture(channel=2).saturation == 1.0
+    assert Moisture(channel=3).saturation == 1.0
 
+    assert Moisture(channel=1).moisture == 0
+    assert Moisture(channel=2).moisture == 0
+    assert Moisture(channel=3).moisture == 0
 
-def test_moisture_cleanup(GPIO, smbus):
-    from grow import moisture
-    moisture.cleanup()
-
-    GPIO.input.assert_called_with(moisture.MOISTURE_1_PIN, 0)
-    GPIO.input.assert_called_with(moisture.MOISTURE_2_PIN, 0)
-    GPIO.input.assert_called_with(moisture.MOISTURE_3_PIN, 0)
 
 def test_pump_setup(GPIO, smbus):
-    from grow import pump
-    moisture._is_setup = False
-    moisture.setup()
-    moisture.setup()
+    from grow.pump import Pump, PUMP_PWM_FREQ
 
-def test_pump_cleanup(GPIO, smbus):
-    from grow import pump
-    pump.cleanup()
+    ch1 = Pump(channel=1)
+    ch2 = Pump(channel=2)
+    ch3 = Pump(channel=3)
 
-    GPIO.input.assert_called_with(moisture.PUMP_1_PIN, 0)
-    GPIO.input.assert_called_with(moisture.PUMP_2_PIN, 0)
-    GPIO.input.assert_called_with(moisture.PUMP_3_PIN, 0)
+    assert GPIO.setup.has_calls([
+        mock.call(ch1._gpio_pin, GPIO.OUT, initial=GPIO.LOW),
+        mock.call(ch2._gpio_pin, GPIO.OUT, initial=GPIO.LOW),
+        mock.call(ch3._gpio_pin, GPIO.OUT, initial=GPIO.LOW)
+    ])
+
+    assert GPIO.PWM.has_calls([
+        mock.call(ch1._gpio_pin, PUMP_PWM_FREQ),
+        mock.call(ch2._gpio_pin, PUMP_PWM_FREQ),
+        mock.call(ch3._gpio_pin, PUMP_PWM_FREQ)
+    ])

--- a/library/tox.ini
+++ b/library/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35},qa
+envlist = py{35,37},qa
 skip_missing_interpreters = True
 
 [testenv]
@@ -14,11 +14,11 @@ deps =
 
 [testenv:qa]
 commands =
-	check-manifest --ignore tox.ini,tests*,.coveragerc
-	python setup.py check -m -r -s
+	check-manifest --ignore tox.ini,tests/*,.coveragerc
+	python setup.py sdist bdist_wheel
+	twine check dist/*
 	flake8 --ignore E501
-	rstcheck README.rst
 deps =
 	check-manifest
 	flake8
-	rstcheck
+	twine


### PR DESCRIPTION
Adds context back to the settings edit screen, showing the current value of Saturation and Frequency when configuring alarm level, dry point and wet point.