### PR TITLE
Adding MQTT Publish Functionality to monitor service

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -80,3 +80,30 @@ An additional `general` section can be used for global settings:
 
 * `alarm_enable` - Whether to enable the alarm
 * `alarm_interval` - The interval at which the alarm should beep (in seconds)
+
+
+## MQTT Settings
+If you want to send the moisture saturation levels somewhere to build a dashboard, or log to a database, MQTT is a great way to do this. You'll need an MQTT broker set up somwhere, [Mosquitto](https://mosquitto.org/) is great choice and runs really well on a Raspberry Pi.
+
+Add the following settings to your `settings.yml` file:
+
+```yaml
+mqtt:
+  mqtt_host: localhost
+  mqtt_port: 1883
+  mqtt_client_id: plantMonitor
+  mqtt_username: plantpi
+  mqtt_password: pimoroni
+  mqtt_topic_root: plants/moisture
+  mqtt_qos: 2
+  mqtt_interval : 30
+```
+
+* `mqtt_host` - This is the hostname or IP address of the server where your MQTT broker is.
+* `mqtt_port` - This is the port number for the broker, usually `1883`.
+* `mqtt_client_id` - This is the Client ID for your monitor service, can be ignored if you dont mind what the broker sees this device as.
+* `mqtt_username` - If you have authentication enabled, this is the username.
+* `mqtt_password` - If you have authentication enabled, this is the password.
+* `mqtt_topic_root` - This is the MQTT topic where the sensor data will be sent.
+* `mqtt_qos` - The QoS Level to publish messages at. Default: `2`.
+* `mqtt_interval` - This is the time interval between publishing readings, in seconds.

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -18,6 +18,8 @@ from grow import Piezo
 from grow.moisture import Moisture
 from grow.pump import Pump
 
+import paho.mqtt.client as mqtt
+
 
 FPS = 10
 
@@ -887,6 +889,11 @@ class Config:
             "alarm_interval",
         ]
 
+        self.mqtt_settings = [
+            "server",
+            "topics"
+        ]
+
     def load(self, settings_file="settings.yml"):
         if len(sys.argv) > 1:
             settings_file = sys.argv[1]
@@ -921,6 +928,9 @@ class Config:
     def get_channel(self, channel_id):
         return self.config.get("channel{}".format(channel_id), {})
 
+    def get_mqtt(self):
+        return self.config.get("mqtt")
+
     def set(self, section, settings):
         if isinstance(settings, dict):
             self.config[section].update(settings)
@@ -938,6 +948,138 @@ class Config:
 
     def set_general(self, settings):
         self.set("general", settings)
+
+
+class MqttController:
+    def __init__(
+        self,
+        channels,
+        enabled=False,
+        mqtt_host="",
+        mqtt_port=1883,
+        mqtt_tls=False,
+        mqtt_username=None,
+        mqtt_password=None,
+        mqtt_debug=False,
+        mqtt_keepalive=60,
+        mqtt_topic_root="plants/",
+        mqtt_qos=2,
+        interval_s=60
+        ):
+        self.channels = channels
+        self.enabled = enabled
+        self.mqtt_host = mqtt_host
+        self.mqtt_port = mqtt_port
+        self.mqtt_tls = mqtt_tls
+        self.mqtt_username = mqtt_username
+        self.mqtt_password = mqtt_password
+        self.mqtt_debug = mqtt_debug
+        self.mqtt_keepalive = mqtt_keepalive
+        self.mqtt_topic_root = mqtt_topic_root
+        self.interval_s = interval_s
+        self.mqtt_qos = mqtt_qos
+        self._connected = False
+        self._time_last_pub = time.time()
+        
+
+
+    def update_from_yml(self, config):
+        if config is not None:
+            print(config)
+            self.enabled = True
+            self.mqtt_host = config.get("mqtt_host", self.mqtt_host)
+            self.mqtt_port = config.get("mqtt_port", self.mqtt_port)
+            self.mqtt_tls = config.get("mqtt_tls", self.mqtt_tls)
+            self.mqtt_username = config.get("mqtt_username", self.mqtt_username)
+            self.mqtt_password = config.get("mqtt_password", self.mqtt_password)
+            self.mqtt_debug = config.get("mqtt_debug", self.mqtt_debug)
+            self.mqtt_keepalive = config.get("mqtt_keepalive", self.mqtt_keepalive)
+            self.mqtt_topic_root = config.get("mqtt_topic_root", self.mqtt_topic_root)
+            self.mqtt_qos = config.get("mqtt_qos", self.mqtt_qos)
+            self.interval_s = config.get("interval_s", self.interval_s)
+        else:
+            self.enabled = False
+    
+    def on_connect(self, mqttc, obj, flags, rc):
+        logging.info(f'mqtt_connect: RC: {rc}')
+
+    def on_message(self, mqttc, obj, msg):
+        logging.info(f'mqtt_message: Topic: {msg.topic}, QOS: {msg.qos}, Payload: {msg.payload}')
+
+    def on_publish(self, mqttc, obj, mid):
+        logging.info(f'mqtt_publish: MID: {mid}')
+
+    def on_subscribe(self, mqttc, obj, mid, granted_qos):
+        logging.info(f'mqtt_subscribe: MID: {mid}, Granted QoS: {granted_qos}')
+
+    def on_log(self,mqttc, obj, level, string):
+        logging.info(f'mqtt_log: {string}')
+
+    def connect(self):
+        self.mqttc = mqtt.Client()
+        #-- TODO - Add MQTT TLS Configuration
+        #if self.mqtt_tls:
+        #if usetls:
+        #if args.tls_version == "tlsv1.2":
+        #tlsVersion = ssl.PROTOCOL_TLSv1_2
+        #elif args.tls_version == "tlsv1.1":
+        #tlsVersion = ssl.PROTOCOL_TLSv1_1
+        #elif args.tls_version == "tlsv1":
+        #tlsVersion = ssl.PROTOCOL_TLSv1
+        #elif args.tls_version is None:
+        #tlsVersion = None
+        #else:
+        #print ("Unknown TLS version - ignoring")
+        #tlsVersion = None
+        #
+        #if not args.insecure:
+        #    cert_required = ssl.CERT_REQUIRED
+        #else:
+        #    cert_required = ssl.CERT_NONE
+        #    
+        #mqttc.tls_set(ca_certs=args.cacerts, certfile=None, keyfile=None, cert_reqs=cert_required, tls_version=tlsVersion)
+        #
+        #if args.insecure:
+        #    mqttc.tls_insecure_set(True)
+
+        if self.mqtt_username: or self.mqtt_password:
+            self.mqttc.username_pw_set(self.mqtt_username, self.mqtt_password)
+
+        self.mqttc.on_message = self.on_message
+        self.mqttc.on_connect = self.on_connect
+        self.mqttc.on_publish = self.on_publish
+        self.mqttc.on_subscribe = self.on_subscribe
+
+        if self.mqtt_debug:
+            self.mqttc.on_log = self.on_log
+
+        logging.info(f'mqtt: Connecting to: {self.mqtt_host}:{self.mqtt_port}')
+        self.mqttc.connect(self.mqtt_host, self.mqtt_port, self.mqtt_keepalive)
+        self.mqttc.loop_start()
+
+    def disconnect(self):
+        self.mqttc.disconnect()
+
+
+    def update(self):
+        if time.time() - self._time_last_pub > self.interval_s:
+
+              for channel in channels:
+                  topic = f'{self.mqtt_topic_root}channel{channel.channel}'
+                  value = channel.sensor.saturation
+                  logging.info(f'mqtt: Publishing: {value} to {topic} at QoS: {self.mqtt_qos}')
+                  self.mqttc.publish(topic, value,qos=self.mqtt_qos))
+            self._time_last_pub = time.time()
+
+        
+
+
+
+    
+
+
+
+
 
 
 def main():
@@ -1055,6 +1197,9 @@ Alarm Interval: {:.2f}s
         ]
     )
 
+    mqttController = MqttController(channels)
+    mqttController.update_from_yml(config.get_mqtt())
+
     while True:
         for channel in channels:
             config.set_channel(channel.channel, channel)
@@ -1066,6 +1211,7 @@ Alarm Interval: {:.2f}s
 
         viewcontroller.update()
         viewcontroller.render()
+        mqttController.update()
         display.display(image.convert("RGB"))
 
         config.set_general(

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -1072,7 +1072,7 @@ class MqttController:
     def update(self):
         if self._enabled:
             self.mqttc.loop()
-            if time.time() - self._time_last_pub > self.interval_s:
+            if time.time() - self._time_last_pub > self.mqtt_interval:
                 moistureDict = {}
                 for channel in self.channels:
                     moistureDict[f'channel{channel.channel}'] = channel.sensor.saturation * 100

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -1057,7 +1057,8 @@ class MqttController:
             self.mqttc.on_log = self.on_log
 
         logging.info(f'mqtt: Connecting to: {self.mqtt_host}:{self.mqtt_port}')
-        self.mqttc.connect(self.mqtt_host, self.mqtt_port, self.mqtt_keepalive)
+        rc = self.mqttc.connect(self.mqtt_host, self.mqtt_port, self.mqtt_keepalive)
+        logging.info("mqtt Connect RC: " + str(rc))
         #self.mqttc.loop_start()
         self._connecting = False
 
@@ -1067,7 +1068,7 @@ class MqttController:
 
     def update(self):
         if not self._connected and not self._connecting:
-            self.connect()
+            #self.connect()
 
         self.mqttc.loop()
 
@@ -1199,6 +1200,7 @@ Alarm Interval: {:.2f}s
 
     mqttController = MqttController(channels)
     mqttController.update_from_yml(config.get_mqtt())
+    mqttController.connect()
 
     while True:
         for channel in channels:

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -1001,6 +1001,7 @@ class MqttController:
             self.enabled = False
     
     def on_connect(self, mqttc, obj, flags, rc):
+        self._connected = True
         logging.info(f'mqtt_connect: RC: {rc}')
 
     def on_message(self, mqttc, obj, msg):
@@ -1042,7 +1043,7 @@ class MqttController:
         #if args.insecure:
         #    mqttc.tls_insecure_set(True)
 
-        if self.mqtt_username: or self.mqtt_password:
+        if self.mqtt_username or self.mqtt_password:
             self.mqttc.username_pw_set(self.mqtt_username, self.mqtt_password)
 
         self.mqttc.on_message = self.on_message
@@ -1062,22 +1063,17 @@ class MqttController:
 
 
     def update(self):
+        if not self._connected:
+            self.connect()
+
         if time.time() - self._time_last_pub > self.interval_s:
 
-              for channel in channels:
-                  topic = f'{self.mqtt_topic_root}channel{channel.channel}'
-                  value = channel.sensor.saturation
-                  logging.info(f'mqtt: Publishing: {value} to {topic} at QoS: {self.mqtt_qos}')
-                  self.mqttc.publish(topic, value,qos=self.mqtt_qos))
+            for channel in self.channels:
+                topic = f'{self.mqtt_topic_root}channel{channel.channel}'
+                value = channel.sensor.saturation
+                logging.info(f'mqtt: Publishing: {value} to {topic} at QoS: {self.mqtt_qos}')
+                self.mqttc.publish(topic, value,qos=self.mqtt_qos)
             self._time_last_pub = time.time()
-
-        
-
-
-
-    
-
-
 
 
 

--- a/examples/settings.yml
+++ b/examples/settings.yml
@@ -23,5 +23,5 @@ mqtt:
   mqtt_password: pimoroni
   mqtt_debug: false
   mqtt_topic_root: plants/moisture
-  interval_s : 30
+  mqtt_interval : 30
 

--- a/examples/settings.yml
+++ b/examples/settings.yml
@@ -16,3 +16,12 @@ channel3:
 general:
   alarm_enable: true
   alarm_interval: 2
+mqtt:
+  mqtt_host: localhost
+  mqtt_port: 1883
+  mqtt_username: plantpi
+  mqtt_password: pimoroni
+  mqtt_debug: false
+  mqtt_topic_root: plants/moisture
+  interval_s : 30
+


### PR DESCRIPTION
The Monitor service is really well made, but I thought it would be good to publish the saturation readings to an MQTT broker as well as onto the display so that they can be logged in a Database.

I've duplicated the existing code pattern as much as possible by adding an `MqttController` Class. If there is an `mqtt` category in the `settings.yml` file, then it will load those settings and connect to the specified MQTT broker on startup. It will then check every loop to see whether it needs to publish the current sensor readings (default every 30 seconds). 

I've added the following to the `README.md` explaining all of the settings:

## MQTT Settings
If you want to send the moisture saturation levels somewhere to build a dashboard, or log to a database, MQTT is a great way to do this. You'll need an MQTT broker set up somwhere, [Mosquitto](https://mosquitto.org/) is great choice and runs really well on a Raspberry Pi.

Add the following settings to your `settings.yml` file:

```yaml
mqtt:
  mqtt_host: localhost
  mqtt_port: 1883
  mqtt_client_id: plantMonitor
  mqtt_username: plantpi
  mqtt_password: pimoroni
  mqtt_topic_root: plants/moisture
  mqtt_qos: 2
  mqtt_interval : 30
```

* `mqtt_host` - This is the hostname or IP address of the server where your MQTT broker is.
* `mqtt_port` - This is the port number for the broker, usually `1883`.
* `mqtt_client_id` - This is the Client ID for your monitor service, can be ignored if you dont mind what the broker sees this device as.
* `mqtt_username` - If you have authentication enabled, this is the username.
* `mqtt_password` - If you have authentication enabled, this is the password.
* `mqtt_topic_root` - This is the MQTT topic where the sensor data will be sent.
* `mqtt_qos` - The QoS Level to publish messages at. Default: `2`.
* `mqtt_interval` - This is the time interval between publishing readings, in seconds.


When you use this MQTT configuration, every time the `mqtt_interval` passes, the saturation levels (0% - 100%) will be published to the configured topic.

```json
{
        "channel1": 18.7,
        "channel2": 2.8,
        "channel3": 68.6
}
```



----------------------------


The only main thing this is missing right now is the configuration logic for TLS settings, but I wanted to get this PR in front of some eyes sooner rather than later to incorporate any feedback. 