### PR TITLE
Add water_level to channel config

### DIFF
--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -935,7 +935,8 @@ class Config:
             "watering_delay",
             "auto_water",
             "pump_time",
-            "pump_speed"
+            "pump_speed",
+            "water_level",
         ]
 
         self.general_settings = [


### PR DESCRIPTION
The water_level value set on a channel does not persist until it is added to the config, this PR fixes that :)