### PR TITLE
Turn off Backlight when the screen is black/blank

### DIFF
--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -1135,9 +1135,10 @@ Low Light Value {:.2f}
         viewcontroller.update()
 
         if light_level_low and config.get_general().get("black_screen_when_light_low"):
+            display.set_backlight(GPIO.LOW)
             display.display(image_blank.convert("RGB"))
-
         else:
+            display.set_backlight(GPIO.HIGH)
             viewcontroller.render()
             display.display(image.convert("RGB"))
 

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -1135,11 +1135,11 @@ Low Light Value {:.2f}
         viewcontroller.update()
 
         if light_level_low and config.get_general().get("black_screen_when_light_low"):
-            display.set_backlight(GPIO.LOW)
+            display.sleep()
             display.display(image_blank.convert("RGB"))
         else:
-            display.set_backlight(GPIO.HIGH)
             viewcontroller.render()
+            display.wake()
             display.display(image.convert("RGB"))
 
         config.set_general(

--- a/library/setup.cfg
+++ b/library/setup.cfg
@@ -30,7 +30,7 @@ python_requires = >= 3
 packages = grow
 install_requires =
 	ltr559
-	st7735
+	st7735>=0.0.5
 	pyyaml
 	fonts
 	font-roboto


### PR DESCRIPTION
Monitor blacks out the screen when the light is low, but it doesn't do anything to the backlight, limiting its functionality.

This change sets the backlight to zero, and restores it back to 12 when the screen is in use

Related to https://github.com/pimoroni/grow-python/issues/16 and https://github.com/pimoroni/grow-python/issues/15

Note that this doesn't mean the display is unpowered, but hopefully it helps