### PR TITLE
Don't render on each frame when the display is blank

### DIFF
--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -1133,12 +1133,12 @@ Low Light Value {:.2f}
         alarm.update(light_level_low)
 
         viewcontroller.update()
-        viewcontroller.render()
 
         if light_level_low and config.get_general().get("black_screen_when_light_low"):
             display.display(image_blank.convert("RGB"))
 
         else:
+            viewcontroller.render()
             display.display(image.convert("RGB"))
 
         config.set_general(


### PR DESCRIPTION
What's the point in updating `image` if we're just going to display the blank one anyway? This should save a tiny bit of CPU/power