### PR TITLE
Bookworm/Pi5 Compatibility: Upgrade to latest boilerplate, port to gpiod

### DIFF
--- a/grow/moisture.py
+++ b/grow/moisture.py
@@ -1,6 +1,13 @@
 import time
+import select
+import threading
+from datetime import timedelta
+import atexit
 
-import RPi.GPIO as GPIO
+import gpiodevice
+from gpiod import LineSettings
+from gpiod.line import Edge, Bias
+
 
 MOISTURE_1_PIN = 23
 MOISTURE_2_PIN = 8
@@ -25,45 +32,54 @@ class Moisture(object):
         """
         self._gpio_pin = [MOISTURE_1_PIN, MOISTURE_2_PIN, MOISTURE_3_PIN, MOISTURE_INT_PIN][channel - 1]
 
-        GPIO.setwarnings(False)
-        GPIO.setmode(GPIO.BCM)
-        GPIO.setup(self._gpio_pin, GPIO.IN)
-
         self._count = 0
         self._reading = 0
         self._history = []
         self._history_length = 200
-        self._last_pulse = time.time()
         self._new_data = False
         self._wet_point = wet_point if wet_point is not None else 0.7
         self._dry_point = dry_point if dry_point is not None else 27.6
-        self._time_last_reading = time.time()
+
+        self._last_reading = 0
+
+        self._int, self._offset = gpiodevice.get_pin(self._gpio_pin, f"grow-m-ch{channel}", LineSettings(
+            edge_detection=Edge.RISING, bias=Bias.PULL_DOWN, debounce_period=timedelta(milliseconds=10)
+        ))
+
+        self._poll_thread_event = threading.Event()
+        self._poll_thread = threading.Thread(target=self._thread_poll)
+        self._poll_thread.start()
+
+        atexit.register(self._thread_stop)
+
+    def __del__(self):
+        self._thread_stop()
+
+    def _thread_stop(self):
+        self._poll_thread_event.set()
+        self._poll_thread.join()
+
+    def _thread_poll(self):
+        poll = select.poll()
         try:
-            GPIO.add_event_detect(self._gpio_pin, GPIO.RISING, callback=self._event_handler, bouncetime=1)
-        except RuntimeError as e:
-            if self._gpio_pin == 8:
-                raise RuntimeError("""Unable to set up edge detection on BCM8.
+            poll.register(self._int.fd, select.POLLIN)
+        except TypeError:
+            return
+        while not self._poll_thread_event.wait(1.0):
+            if not poll.poll(0):
+                # No pulses in 1s, this is not a valid reading
+                continue
 
-Please ensure you add the following to /boot/config.txt and reboot:
-
-dtoverlay=spi0-cs,cs0_pin=14 # Re-assign CS0 from BCM 8 so that Grow can use it
-
-""")
-            else:
-                raise e
-
-        self._time_start = time.time()
-
-    def _event_handler(self, pin):
-        self._count += 1
-        self._last_pulse = time.time()
-        if self._time_elapsed >= 1.0:
-            self._reading = self._count / self._time_elapsed
+            # We got pulses, since we waited for 1s we can be relatively
+            # sure the number of pulses is approximately the sensor frequency
+            events = self._int.read_edge_events()
+            self._last_reading = time.time()
+            self._reading = len(events)  # Pulse frequency
             self._history.insert(0, self._reading)
             self._history = self._history[:self._history_length]
-            self._count = 0
-            self._time_last_reading = time.time()
             self._new_data = True
+
+        poll.unregister(self._int.fd)
 
     @property
     def history(self):
@@ -75,10 +91,6 @@ dtoverlay=spi0-cs,cs0_pin=14 # Re-assign CS0 from BCM 8 so that Grow can use it
             history.append(max(0.0, min(1.0, saturation)))
 
         return history
-
-    @property
-    def _time_elapsed(self):
-        return time.time() - self._time_last_reading
 
     def set_wet_point(self, value=None):
         """Set the sensor wet point.
@@ -123,7 +135,7 @@ dtoverlay=spi0-cs,cs0_pin=14 # Re-assign CS0 from BCM 8 so that Grow can use it
     @property
     def active(self):
         """Check if the moisture sensor is producing a valid reading."""
-        return (time.time() - self._last_pulse) < 1.0 and self._reading > 0 and self._reading < 28
+        return (time.time() - self._last_reading) <= 1.0 and self._reading > 0 and self._reading < 28
 
     @property
     def new_data(self):

--- a/grow/moisture.py
+++ b/grow/moisture.py
@@ -1,13 +1,12 @@
-import time
+import atexit
 import select
 import threading
+import time
 from datetime import timedelta
-import atexit
 
 import gpiodevice
 from gpiod import LineSettings
-from gpiod.line import Edge, Bias
-
+from gpiod.line import Bias, Edge
 
 MOISTURE_1_PIN = 23
 MOISTURE_2_PIN = 8

--- a/grow/pwm.py
+++ b/grow/pwm.py
@@ -1,0 +1,106 @@
+import time
+from threading import Thread
+
+import gpiod
+import gpiodevice
+from gpiod.line import Direction, Value
+
+OUTL = gpiod.LineSettings(direction=Direction.OUTPUT, output_value=Value.INACTIVE)
+
+
+class PWM:
+    _pwms: list = []
+    _t_pwm: Thread = None
+    _pwm_running: bool = False
+
+    @staticmethod
+    def start_thread():
+        if PWM._t_pwm is None:
+            PWM._pwm_running = True
+            PWM._t_pwm = Thread(target=PWM._run)
+            PWM._t_pwm.start()
+
+    @staticmethod
+    def stop_thread():
+        if PWM._t_pwm is not None:
+            PWM._pwm_running = False
+            PWM._t_pwm.join()
+            PWM._t_pwm = None
+
+    @staticmethod
+    def _add(pwm):
+        PWM._pwms.append(pwm)
+
+    @staticmethod
+    def _remove(pwm):
+        index = PWM._pwms.index(pwm)
+        del PWM._pwms[index]
+        if len(PWM._pwms) == 0:
+            PWM.stop_thread()
+
+    @staticmethod
+    def _run():
+        while PWM._pwm_running:
+            PWM.run()
+
+    @staticmethod
+    def run():
+        for pwm in PWM._pwms:
+            pwm.next(time.time())
+
+    def __init__(self, pin, frequency=0, duty_cycle=0, lines=None, offset=None):
+        self.duty_cycle = 0
+        self.frequency = 0
+        self.duty_period = 0
+        self.period = 0
+        self.running = False
+        self.time_start = None
+        self.state = Value.ACTIVE
+
+        self.set_frequency(frequency)
+        self.set_duty_cycle(duty_cycle)
+
+        if isinstance(pin, tuple):
+            self.lines, self.offset = pin
+        else:
+            self.lines, self.offset = gpiodevice.get_pin(pin, "PWM", OUTL)
+
+        PWM._add(self)
+
+    def set_frequency(self, frequency):
+        if frequency == 0:
+            return
+        self.frequency = frequency
+        self.period = 1.0 / frequency
+        self.duty_period = self.duty_cycle * self.period
+
+    def set_duty_cycle(self, duty_cycle):
+        self.duty_cycle = duty_cycle
+        self.duty_period = self.duty_cycle * self.period
+
+    def start(self, duty_cycle=None, frequency=None, start_time=None):
+        if duty_cycle is not None:
+            self.set_duty_cycle(duty_cycle)
+
+        if frequency is not None:
+            self.set_frequency(frequency)
+
+        self.time_start = time.time() if start_time is None else start_time
+
+        self.running = True
+
+    def next(self, t):
+        if not self.running:
+            return
+        d = t - self.time_start
+        d %= self.period
+        new_state = Value.ACTIVE if d < self.duty_period else Value.INACTIVE
+        if new_state != self.state:
+            self.lines.set_value(self.offset, new_state)
+            self.state = new_state
+
+    def stop(self):
+        self.running = False
+
+    def __del__(self):
+        PWM._remove(self)

--- a/grow/pwm.py
+++ b/grow/pwm.py
@@ -1,5 +1,5 @@
 import time
-from threading import Thread
+from threading import Event, Thread
 
 import gpiod
 import gpiodevice
@@ -11,19 +11,18 @@ OUTL = gpiod.LineSettings(direction=Direction.OUTPUT, output_value=Value.INACTIV
 class PWM:
     _pwms: list = []
     _t_pwm: Thread = None
-    _pwm_running: bool = False
+    _t_pwm_event: Event = Event()
 
     @staticmethod
     def start_thread():
         if PWM._t_pwm is None:
-            PWM._pwm_running = True
             PWM._t_pwm = Thread(target=PWM._run)
             PWM._t_pwm.start()
 
     @staticmethod
     def stop_thread():
         if PWM._t_pwm is not None:
-            PWM._pwm_running = False
+            PWM._t_pwm_event.set()
             PWM._t_pwm.join()
             PWM._t_pwm = None
 
@@ -34,13 +33,13 @@ class PWM:
     @staticmethod
     def _remove(pwm):
         index = PWM._pwms.index(pwm)
-        del PWM._pwms[index]
+        PWM._pwms.pop(index)
         if len(PWM._pwms) == 0:
             PWM.stop_thread()
 
     @staticmethod
     def _run():
-        while PWM._pwm_running:
+        while not PWM._t_pwm_event.is_set():
             PWM.run()
 
     @staticmethod

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ DATESTAMP=$(date "+%Y-%m-%d-%H-%M-%S")
 CONFIG_BACKUP=false
 APT_HAS_UPDATED=false
 RESOURCES_TOP_DIR=$HOME/Pimoroni
-VENV_BASH_SNIPPET=$RESOURCES_DIR/auto_venv.sh
+VENV_BASH_SNIPPET=$RESOURCES_TOP_DIR/auto_venv.sh
 VENV_DIR=$HOME/.virtualenvs/pimoroni
 WD=$(pwd)
 USAGE="./install.sh (--unstable)"
@@ -77,7 +77,7 @@ find_config() {
 venv_bash_snippet() {
 	if [ ! -f "$VENV_BASH_SNIPPET" ]; then
 		cat << EOF > "$VENV_BASH_SNIPPET"
-# Add `source $RESOURCES_DIR/auto_venv.sh` to your ~/.bashrc to activate
+# Add `source "$VENV_BASH_SNIPPET"` to your ~/.bashrc to activate
 # the Pimoroni virtual environment automagically!
 VENV_DIR="$VENV_DIR"
 if [ ! -f \$VENV_DIR/bin/activate ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,10 @@ classifiers = [
     "Topic :: System :: Hardware",
 ]
 dependencies = [
-	"ltr559",
-	"st7735>=0.0.5",
+    "gpiodevice",
+    "gpiod>=2.1.3",
+	"ltr559>=1.0.0",
+	"st7735>=1.0.0",
 	"pyyaml",
 	"fonts",
 	"font-roboto"
@@ -121,5 +123,11 @@ ignore = [
 
 [tool.pimoroni]
 apt_packages = []
-configtxt = []
-commands = []
+configtxt = [
+    "dtoverlay=spi0-cs,cs0_pin=14" # Re-assign CS0 from BCM 8 so that Grow can use it
+]
+commands = [
+    "printf \"Setting up i2c and SPI..\\n\"",
+	"sudo raspi-config nonint do_spi 0",
+	"sudo raspi-config nonint do_i2c 0"
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,31 +18,20 @@ class SMBusFakeDevice(MockSMBus):
 @pytest.fixture(scope='function', autouse=True)
 def cleanup():
     yield None
-    try:
-        del sys.modules['grow']
-    except KeyError:
-        pass
-    try:
-        del sys.modules['grow.moisture']
-    except KeyError:
-        pass
-    try:
-        del sys.modules['grow.pump']
-    except KeyError:
-        pass
+    for module in ['grow', 'grow.moisture', 'grow.pump']:
+        try:
+            del sys.modules[module]
+        except KeyError:
+            continue
 
 
 @pytest.fixture(scope='function', autouse=False)
 def GPIO():
-    """Mock RPi.GPIO module."""
-    GPIO = mock.MagicMock()
-    # Fudge for Python < 37 (possibly earlier)
-    sys.modules['RPi'] = mock.Mock()
-    sys.modules['RPi'].GPIO = GPIO
-    sys.modules['RPi.GPIO'] = GPIO
-    yield GPIO
-    del sys.modules['RPi']
-    del sys.modules['RPi.GPIO']
+    """Mock gpiod module."""
+    gpiod = mock.MagicMock()
+    sys.modules['gpiod'] = gpiod
+    yield gpiod
+    del sys.modules['gpiod']
 
 
 @pytest.fixture(scope='function', autouse=False)
@@ -55,13 +44,13 @@ def spidev():
 
 
 @pytest.fixture(scope='function', autouse=False)
-def smbus():
-    """Mock smbus module."""
-    smbus = mock.MagicMock()
-    smbus.SMBus = SMBusFakeDevice
-    sys.modules['smbus'] = smbus
-    yield smbus
-    del sys.modules['smbus']
+def smbus2():
+    """Mock smbus2 module."""
+    smbus2 = mock.MagicMock()
+    smbus2.SMBus = SMBusFakeDevice
+    sys.modules['smbus2'] = smbus2
+    yield smbus2
+    del sys.modules['smbus2']
 
 
 @pytest.fixture(scope='function', autouse=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,12 +26,24 @@ def cleanup():
 
 
 @pytest.fixture(scope='function', autouse=False)
-def GPIO():
+def gpiod():
     """Mock gpiod module."""
-    gpiod = mock.MagicMock()
-    sys.modules['gpiod'] = gpiod
-    yield gpiod
-    del sys.modules['gpiod']
+    sys.modules["gpiod"] = mock.Mock()
+    sys.modules["gpiod.line"] = mock.Mock()
+    yield sys.modules["gpiod"]
+    del sys.modules["gpiod.line"]
+    del sys.modules["gpiod"]
+
+
+@pytest.fixture(scope="function", autouse=False)
+def gpiodevice():
+    gpiodevice = mock.Mock()
+    gpiodevice.get_pins_for_platform.return_value = [(mock.Mock(), 0), (mock.Mock(), 0), (mock.Mock(), 0)]
+    gpiodevice.get_pin.return_value = (mock.Mock(), 0)
+
+    sys.modules["gpiodevice"] = gpiodevice
+    yield gpiodevice
+    del sys.modules["gpiodevice"]
 
 
 @pytest.fixture(scope='function', autouse=False)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,7 +1,7 @@
 import time
 
 
-def test_pumps_actually_stop(GPIO, smbus):
+def test_pumps_actually_stop(gpiod, smbus2):
     from grow.pump import Pump
 
     ch1 = Pump(channel=1)
@@ -11,7 +11,7 @@ def test_pumps_actually_stop(GPIO, smbus):
     assert ch1.get_speed() == 0
 
 
-def test_pumps_are_mutually_exclusive(GPIO, smbus):
+def test_pumps_are_mutually_exclusive(gpiod, smbus2):
     from grow.pump import Pump, global_lock
 
     ch1 = Pump(channel=1)
@@ -29,7 +29,7 @@ def test_pumps_are_mutually_exclusive(GPIO, smbus):
     assert ch3.dose(speed=0.5, blocking=False) is False
 
 
-def test_pumps_run_sequentially(GPIO, smbus):
+def test_pumps_run_sequentially(gpiod, smbus2):
     from grow.pump import Pump, global_lock
 
     ch1 = Pump(channel=1)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,8 +1,9 @@
 import time
 
 
-def test_pumps_actually_stop(gpiod, smbus2):
+def test_pumps_actually_stop(gpiod, gpiodevice, smbus2):
     from grow.pump import Pump
+    from grow.pwm import PWM
 
     ch1 = Pump(channel=1)
 
@@ -10,9 +11,13 @@ def test_pumps_actually_stop(gpiod, smbus2):
     time.sleep(0.1)
     assert ch1.get_speed() == 0
 
+    PWM.stop_thread()
 
-def test_pumps_are_mutually_exclusive(gpiod, smbus2):
+
+
+def test_pumps_are_mutually_exclusive(gpiod, gpiodevice, smbus2):
     from grow.pump import Pump, global_lock
+    from grow.pwm import PWM
 
     ch1 = Pump(channel=1)
     ch2 = Pump(channel=2)
@@ -28,9 +33,13 @@ def test_pumps_are_mutually_exclusive(gpiod, smbus2):
     assert ch3.dose(speed=0.5) is False
     assert ch3.dose(speed=0.5, blocking=False) is False
 
+    PWM.stop_thread()
 
-def test_pumps_run_sequentially(gpiod, smbus2):
+
+
+def test_pumps_run_sequentially(gpiod, gpiodevice, smbus2):
     from grow.pump import Pump, global_lock
+    from grow.pwm import PWM
 
     ch1 = Pump(channel=1)
     ch2 = Pump(channel=2)
@@ -45,3 +54,5 @@ def test_pumps_run_sequentially(gpiod, smbus2):
     assert ch3.dose(speed=0.5, timeout=0.1, blocking=False) is True
     assert global_lock.locked() is True
     time.sleep(0.3)
+
+    PWM.stop_thread()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,7 +1,7 @@
 import mock
 
 
-def test_moisture_setup(GPIO, smbus):
+def test_moisture_setup(gpiod, smbus2):
     from grow.moisture import Moisture
 
     ch1 = Moisture(channel=1)
@@ -15,7 +15,7 @@ def test_moisture_setup(GPIO, smbus):
     ])
 
 
-def test_moisture_read(GPIO, smbus):
+def test_moisture_read(gpiod, smbus2):
     from grow.moisture import Moisture
 
     assert Moisture(channel=1).saturation == 1.0
@@ -27,7 +27,7 @@ def test_moisture_read(GPIO, smbus):
     assert Moisture(channel=3).moisture == 0
 
 
-def test_pump_setup(GPIO, smbus):
+def test_pump_setup(gpiod, smbus2):
     from grow.pump import PUMP_PWM_FREQ, Pump
 
     ch1 = Pump(channel=1)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,21 +1,16 @@
 import mock
 
 
-def test_moisture_setup(gpiod, smbus2):
+def test_moisture_setup(gpiod, gpiodevice, smbus2):
     from grow.moisture import Moisture
+    from datetime import timedelta
 
     ch1 = Moisture(channel=1)
     ch2 = Moisture(channel=2)
     ch3 = Moisture(channel=3)
 
-    GPIO.setup.assert_has_calls([
-        mock.call(ch1._gpio_pin, GPIO.IN),
-        mock.call(ch2._gpio_pin, GPIO.IN),
-        mock.call(ch3._gpio_pin, GPIO.IN)
-    ])
 
-
-def test_moisture_read(gpiod, smbus2):
+def test_moisture_read(gpiod, gpiodevice, smbus2):
     from grow.moisture import Moisture
 
     assert Moisture(channel=1).saturation == 1.0
@@ -27,24 +22,14 @@ def test_moisture_read(gpiod, smbus2):
     assert Moisture(channel=3).moisture == 0
 
 
-def test_pump_setup(gpiod, smbus2):
+def test_pump_setup(gpiod, gpiodevice, smbus2):
     from grow.pump import PUMP_PWM_FREQ, Pump
+    from grow.pwm import PWM
 
     ch1 = Pump(channel=1)
     ch2 = Pump(channel=2)
     ch3 = Pump(channel=3)
 
-    GPIO.setup.assert_has_calls([
-        mock.call(ch1._gpio_pin, GPIO.OUT, initial=GPIO.LOW),
-        mock.call(ch2._gpio_pin, GPIO.OUT, initial=GPIO.LOW),
-        mock.call(ch3._gpio_pin, GPIO.OUT, initial=GPIO.LOW)
-    ])
+    # Threads. Not even once.
+    PWM.stop_thread()
 
-    GPIO.PWM.assert_has_calls([
-        mock.call(ch1._gpio_pin, PUMP_PWM_FREQ),
-        mock.call().start(0),
-        mock.call(ch2._gpio_pin, PUMP_PWM_FREQ),
-        mock.call().start(0),
-        mock.call(ch3._gpio_pin, PUMP_PWM_FREQ),
-        mock.call().start(0)
-    ])

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,14 +1,9 @@
-import mock
-
-
 def test_moisture_setup(gpiod, gpiodevice, smbus2):
-    from datetime import timedelta
-
     from grow.moisture import Moisture
 
-    ch1 = Moisture(channel=1)
-    ch2 = Moisture(channel=2)
-    ch3 = Moisture(channel=3)
+    _ = Moisture(channel=1)
+    _ = Moisture(channel=2)
+    _ = Moisture(channel=3)
 
 
 def test_moisture_read(gpiod, gpiodevice, smbus2):
@@ -24,12 +19,12 @@ def test_moisture_read(gpiod, gpiodevice, smbus2):
 
 
 def test_pump_setup(gpiod, gpiodevice, smbus2):
-    from grow.pump import PUMP_PWM_FREQ, Pump
+    from grow.pump import Pump
     from grow.pwm import PWM
 
-    ch1 = Pump(channel=1)
-    ch2 = Pump(channel=2)
-    ch3 = Pump(channel=3)
+    _ = Pump(channel=1)
+    _ = Pump(channel=2)
+    _ = Pump(channel=3)
 
     # Threads. Not even once.
     PWM.stop_thread()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2,8 +2,9 @@ import mock
 
 
 def test_moisture_setup(gpiod, gpiodevice, smbus2):
-    from grow.moisture import Moisture
     from datetime import timedelta
+
+    from grow.moisture import Moisture
 
     ch1 = Moisture(channel=1)
     ch2 = Moisture(channel=2)

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
 	python -m build --no-isolation
 	python -m twine check dist/*
 	isort --check .
-	ruff .
+	ruff check .
 	codespell .
 deps =
 	check-manifest


### PR DESCRIPTION
# TODO

* [ ] - Can we make Python-based soft PWM work for pumps and piezos, or do we need to do something else?
* [ ] - Update tests

# PWM

Since Grow assumes we can PWM any pin- because RPi.GPIO had a software kludge to let us do so - we're in a bit of a predicament porting this to Bookworm / gpiod. I've experimented with pure Python PWM and it works, but it's thoroughly irredeemably terrible. When dealing with pumps that involve water- I don't want to invite the risk of a software failure causing a flood.

There's a patch floating about for software PWM at the kernel level, so we should be switching to standard PWM interfaces (see: https://lore.kernel.org/linux-pwm/20240204220851.4783-1-wahrenst@gmx.net/) with the hope that the Pi 5 will eventually get PIO PWM support on arbitrary pins.

Until the PWM issue is resolved, then Pi 5 support for Grow is blocked.

UPDATE: GPIO PWM is now merged into mainline Linux, Kernel 6.11, we're now waiting for it to make it into a Raspberry Pi OS release: https://github.com/torvalds/linux/commit/7f61257cd6e1ad4769b4b819668cab00f68f2556

# Testing

If you're a Bookworm / Pi 5 user running into virtual environment issues, you can try this library like so:

```
git clone https://github.com/pimoroni/grow-python -b gpiod
cd grow-python
./install.sh --unstable
```

The `./install.sh` script will create a `pimoroni` virtual environment that's shared between our products. (or use your existing venv if you've already activated one.)

For the reasons behind these changes and other information, see:

* https://github.com/pimoroni/boilerplate-python/pull/13
* https://github.com/pimoroni/boilerplate-python/issues/16
* https://pimoroni.github.io/venv-python/