### PR TITLE
fix: mismatch between required Pillow version and monitoring implementation

### DIFF
--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -90,7 +90,7 @@ class View:
         if position not in ["A", "B", "X", "Y"]:
             raise ValueError(f"Invalid label position {position}")
 
-        text_w, text_h = self._draw.textsize(text, font=self.font)
+        _, _, text_w, text_h = self._draw.textbbox((0, 0), text, font=self.font)
         text_h = 11
         text_w += margin * 2
         text_h += margin * 2
@@ -143,7 +143,7 @@ class View:
 
                 while (
                     len(words) > 0
-                    and font.getsize(" ".join(line + [words[0]]))[0] <= width
+                    and font.getbbox(" ".join(line + [words[0]]))[2] <= width
                 ):
                     line.append(words.pop(0))
 
@@ -161,7 +161,7 @@ class View:
                 bounds = [x2, y, x1, y + len(lines) * line_height]
 
                 for line in lines:
-                    line_width = font.getsize(line)[0]
+                    line_width = font.getbbox(line)[2]
                     x = int(x1 + (width / 2) - (line_width / 2))
                     bounds[0] = min(bounds[0], x)
                     bounds[2] = max(bounds[2], x + line_width)
@@ -222,7 +222,7 @@ class MainView(View):
         self.icon(icon_channel, (x, label_y), (200, 200, 200) if active else (64, 64, 64))
 
         # TODO: replace number text with graphic
-        tw, th = self.font.getsize(str(channel.channel))
+        _, _, tw, th = self.font.getbbox(str(channel.channel))
         self._draw.text(
             (x + int(math.ceil(8 - (tw / 2.0))), label_y + 1),
             str(channel.channel),
@@ -479,7 +479,7 @@ class DetailView(ChannelView):
 
         self.icon(icon_channel, (label_x, label_y), (200, 200, 200))
 
-        tw, th = self.font.getsize(str(self.channel.channel))
+        _, _, tw, th = self.font.getbbox(str(self.channel.channel))
         self._draw.text(
             (label_x + int(math.ceil(8 - (tw / 2.0))), label_y + 1),
             str(self.channel.channel),


### PR DESCRIPTION
Hi there! To begin with, thank you for your amazing products. This tiny PR suggests a fix in _example/monitoring.py_, consisting of replacing `ImageDraw.textsize` and `FreeTypeFont.getsize` by `textbbox` and `getbbox` method respectively, since the former have been removed from `Pillow` versions greater than 9.5, whereas the currently requested version must be greater than 10.

Of course, we could alternatively change the Pillow version requirement. Up to you.