### PR TITLE
Modernize examples and fix deprecation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ library/debian/
 .pytest_cache
 .tox
 .vscode/
+.env
+pimoroni/
+
+CLAUDE.md
+SECURITY_REVIEW.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+0.0.4
+-----
+
+* Fix wrong GPIO pin for pump2 on Raspberry Pi 5 (PIN12 -> PIN13)
+* Fix PWM thread event never cleared after stop, preventing restart
+* Fix PWM destructor crash if constructor fails midway
+* Fix Moisture destructor crash if constructor fails midway
+* Fix PWM ZeroDivisionError when frequency is zero
+* Migrate examples/monitor.py from RPi.GPIO to gpiod for button handling
+
 0.0.3
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Fix Moisture destructor crash if constructor fails midway
 * Fix PWM ZeroDivisionError when frequency is zero
 * Migrate examples/monitor.py from RPi.GPIO to gpiod for button handling
+* Fix PWM initial state mismatch with GPIO configuration
+* Fix PWM thread busy-wait consuming 100% CPU
+* Fix PWM stop not setting GPIO to inactive state
 
 0.0.3
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * Fix PWM initial state mismatch with GPIO configuration
 * Fix PWM thread busy-wait consuming 100% CPU
 * Fix PWM stop not setting GPIO to inactive state
+* Update ST7735 import to use modern lowercase module name
+* Replace deprecated fonts.ttf with direct font_roboto import (removes pkg_resources deprecation warning)
+* Add setuptools to install.sh dependencies
 
 0.0.3
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+0.0.3
+-----
+
+* Port to gpiod/gpiodevice for Raspberry Pi 5 support
+* Migrate to Pillow 11.x compatible API (Debian Trixie)
+* Require Python 3.9+ (drop Python 3.7/3.8 support)
+* Add Python 3.12 support
+* Use stdlib unittest.mock instead of mock package
+* Fix uninitialized _speed attribute in Pump class
+
 0.0.2
 -----
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ curl -sSL https://get.pimoroni.com/grow | bash
 * Install dependencies:
 
 ```
-sudo apt install python3-setuptools python3-pip python3-yaml python3-smbus python3-pil python3-spidev python3-rpi.gpio
+sudo apt install python3-setuptools python3-pip python3-yaml python3-smbus python3-pil python3-spidev python3-libgpiod
 ```
 
 * Run `sudo pip3 install growhat`
@@ -57,6 +57,16 @@ You should read the following to get up and running with our monitoring script:
 * Discord - https://discord.gg/hr93ByC
 
 # Changelog
+0.0.3
+-----
+
+* Port to gpiod/gpiodevice for Raspberry Pi 5 support
+* Migrate to Pillow 11.x compatible API (Debian Trixie)
+* Require Python 3.9+ (drop Python 3.7/3.8 support)
+* Add Python 3.12 support
+* Use stdlib unittest.mock instead of mock package
+* Fix uninitialized _speed attribute in Pump class
+
 0.0.2
 -----
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ python3 -m venv pimoroni
 * Fix PWM initial state mismatch with GPIO configuration
 * Fix PWM thread busy-wait consuming 100% CPU
 * Fix PWM stop not setting GPIO to inactive state
+* Update ST7735 import to use modern lowercase module name
+* Replace deprecated fonts.ttf with direct font_roboto import (removes pkg_resources deprecation warning)
+* Add setuptools to install.sh dependencies
 
 0.0.3
 -----

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ You should read the following to get up and running with our monitoring script:
 * Discord - https://discord.gg/hr93ByC
 
 # Changelog
+0.0.4
+-----
+
+* Fix wrong GPIO pin for pump2 on Raspberry Pi 5 (PIN12 -> PIN13)
+* Fix PWM thread event never cleared after stop, preventing restart
+* Fix PWM destructor crash if constructor fails midway
+* Fix Moisture destructor crash if constructor fails midway
+* Fix PWM ZeroDivisionError when frequency is zero
+* Migrate examples/monitor.py from RPi.GPIO to gpiod for button handling
+* Fix PWM initial state mismatch with GPIO configuration
+* Fix PWM thread busy-wait consuming 100% CPU
+* Fix PWM stop not setting GPIO to inactive state
+
 0.0.3
 -----
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@
 
 Designed as a tiny valet for your plants, Grow HAT mini will monitor the soil moiture for up to 3 plants, water them with tiny pumps, and show you their health on its small but informative screen. Learn more - https://shop.pimoroni.com/products/grow
 
-[![Build Status](https://img.shields.io/github/actions/workflow/status/pimoroni/grow-python/test.yml?branch=main)](https://github.com/pimoroni/grow-python/actions/workflows/test.yml)
-[![Coverage Status](https://coveralls.io/repos/github/pimoroni/grow-python/badge.svg?branch=master)](https://coveralls.io/github/pimoroni/grow-python?branch=master)
-[![PyPi Package](https://img.shields.io/pypi/v/growhat.svg)](https://pypi.python.org/pypi/growhat)
-[![Python Versions](https://img.shields.io/pypi/pyversions/growhat.svg)](https://pypi.python.org/pypi/growhat)
+## Supported Platforms
+
+| Platform | OS | Status |
+|----------|-----|--------|
+| Raspberry Pi 4 | Debian Trixie | ✅ Tested |
+| Raspberry Pi 4 | Debian Bookworm | ✅ Supported |
+| Raspberry Pi 5 | Debian Bookworm | ✅ Supported |
+
+**Requirements:** Python 3.9+, gpiod 2.1.3+
 
 # Installing
 
@@ -49,6 +54,28 @@ You should read the following to get up and running with our monitoring script:
 
 * [Using and configuring monitor.py](examples/README.md)
 * [Setting up monitor.py as a service](service/README.md)
+
+## Testing
+
+Run unit tests:
+```bash
+python -m pytest tests/ -v
+```
+
+Run QA checks:
+```bash
+ruff check .
+isort --check .
+codespell .
+```
+
+## Development Setup
+
+```bash
+python3 -m venv pimoroni
+./pimoroni/bin/pip install -e .
+./pimoroni/bin/pip install pytest pytest-cov ruff isort codespell
+```
 
 ## Help & Support
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -55,7 +55,7 @@ sudo raspi-config nonint do_spi 0
 The following dependencies are required:
 
 ```
-sudo apt install python3-yaml python3-smbus python3-pil python3-spidev python3-libgpiod
+sudo apt install python3-yaml python3-smbus python3-pil python3-spidev python3-libgpiod python3-setuptools
 ```
 
 ### Installing the library
@@ -64,7 +64,9 @@ sudo apt install python3-yaml python3-smbus python3-pil python3-spidev python3-l
 python3 -m pip install growhat
 ```
 
-This will also install the display driver - ST7735 - and a driver for the light sensor - LTR559.
+This will also install the display driver - st7735 - and a driver for the light sensor - LTR559.
+
+**Note:** When importing the display driver in your code, use lowercase: `import st7735` (not `ST7735`).
 
 ## Reference
 
@@ -277,7 +279,9 @@ The ST7735 display on Grow is 160x80 pixels and a great way to convey current wa
 The display must be set up like so:
 
 ```python
-display = ST7735.ST7735(
+import st7735
+
+display = st7735.ST7735(
     port=0,
     cs=1,               # Chip select 1 (BCM )
     dc=9,               # BCM 9 is the data/command pin

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -26,13 +26,15 @@
 
 ## Getting Started
 
-You'll need to install the LTP305 software library and enable i2c on your Raspberry Pi.
+You'll need to install the Grow HAT software library and enable i2c on your Raspberry Pi.
+
+This library supports both Raspberry Pi 4 and Raspberry Pi 5 using the modern gpiod interface.
 
 ### Requirements
 
-#### Python 3 & pip
+#### Python 3.9+ & pip
 
-You should use Python 3, which may need installing on your Pi:
+You should use Python 3.9 or newer. On recent Raspberry Pi OS versions this is installed by default:
 
 ```
 sudo apt update
@@ -53,7 +55,7 @@ sudo raspi-config nonint do_spi 0
 The following dependencies are required:
 
 ```
-sudo apt install python3-yaml python3-smbus python3-pil python3-spidev python3-rpi.gpio
+sudo apt install python3-yaml python3-smbus python3-pil python3-spidev python3-libgpiod
 ```
 
 ### Installing the library
@@ -66,7 +68,7 @@ This will also install the display driver - ST7735 - and a driver for the light 
 
 ## Reference
 
-The Grow library includes several modules for monitoring, watering and conveying status information.
+The Grow library includes several modules for monitoring, watering and conveying status information. It uses the modern gpiod interface for GPIO access, providing compatibility with both Raspberry Pi 4 and Raspberry Pi 5.
 
 ### Moisture
 

--- a/TEST_REPORT.md
+++ b/TEST_REPORT.md
@@ -1,0 +1,131 @@
+# Grow HAT Mini - Test Report
+
+**Date:** 2026-02-01
+**Version:** 0.0.4
+**Platform:** Raspberry Pi 4
+**OS:** Debian Trixie (Testing)
+
+---
+
+## Environment
+
+| Component | Version |
+|-----------|---------|
+| Python | 3.13.5 |
+| grow | 0.0.4 |
+| gpiod | 2.4.0 |
+| Pillow | 12.1.0 |
+| pytest | 9.0.2 |
+| GPIO Chip | pinctrl-bcm2711 (58 lines) |
+
+---
+
+## Unit Tests
+
+```
+============================= test session starts ==============================
+platform linux -- Python 3.13.5, pytest-9.0.2, pluggy-1.6.0
+rootdir: /home/latte/grow-python
+configfile: pyproject.toml
+plugins: cov-7.0.0
+collected 6 items
+
+tests/test_lock.py::test_pumps_actually_stop PASSED                      [ 16%]
+tests/test_lock.py::test_pumps_are_mutually_exclusive PASSED             [ 33%]
+tests/test_lock.py::test_pumps_run_sequentially PASSED                   [ 50%]
+tests/test_setup.py::test_moisture_setup PASSED                          [ 66%]
+tests/test_setup.py::test_moisture_read PASSED                           [ 83%]
+tests/test_setup.py::test_pump_setup PASSED                              [100%]
+
+============================== 6 passed in 1.15s ===============================
+```
+
+| Test | Description | Status |
+|------|-------------|--------|
+| test_pumps_actually_stop | Verify pumps stop correctly | ✅ PASSED |
+| test_pumps_are_mutually_exclusive | Verify pump locking mechanism | ✅ PASSED |
+| test_pumps_run_sequentially | Verify sequential pump operation | ✅ PASSED |
+| test_moisture_setup | Verify moisture sensor initialization | ✅ PASSED |
+| test_moisture_read | Verify moisture sensor reading | ✅ PASSED |
+| test_pump_setup | Verify pump initialization | ✅ PASSED |
+
+---
+
+## QA Checks
+
+| Tool | Description | Status |
+|------|-------------|--------|
+| isort | Import sorting | ✅ OK |
+| ruff | Linting | ✅ All checks passed |
+| codespell | Spelling | ✅ OK |
+
+---
+
+## Hardware Tests
+
+Tests performed on actual Raspberry Pi 4 hardware with Grow HAT Mini connected.
+
+### LTR559 Light Sensor (I2C)
+
+| Test | Result |
+|------|--------|
+| Initialization | ✅ OK |
+| Lux reading | 0.0 |
+| Proximity reading | 0 |
+
+### ST7735 Display (SPI)
+
+| Test | Result |
+|------|--------|
+| Initialization | ✅ OK |
+| Display test pattern | ✅ OK |
+| Text rendering | ✅ OK |
+
+Test pattern displayed: "Grow HAT v0.0.4 / Pi 4 + Trixie"
+
+### GPIO Access (gpiod)
+
+| Test | Result |
+|------|--------|
+| Chip detection | ✅ OK |
+| Chip name | pinctrl-bcm2711 |
+| Available lines | 58 |
+
+### Pump GPIO
+
+| Test | Result |
+|------|--------|
+| Pump 1 initialization | ✅ OK |
+| PWM thread start | ✅ OK |
+| PWM thread stop | ✅ OK |
+| Initial speed | 0 |
+
+---
+
+## Installation Test
+
+```bash
+./install.sh --unstable --force
+```
+
+| Step | Status |
+|------|--------|
+| Virtual environment detection | ✅ OK |
+| Package installation | ✅ OK |
+| Config backup | ✅ OK |
+| SPI/I2C configuration | ✅ OK |
+| Examples copied | ✅ OK |
+| Documentation generated | ✅ OK |
+
+---
+
+## Summary
+
+**Overall Status:** ✅ ALL TESTS PASSED
+
+- 6/6 unit tests passing
+- 3/3 QA checks passing
+- 4/4 hardware components verified
+- Installation script functional
+
+The gpiod port is fully functional on Raspberry Pi 4 with Debian Trixie.

--- a/examples/advanced/lcd-demo.py
+++ b/examples/advanced/lcd-demo.py
@@ -43,7 +43,8 @@ text_colour = (255, 255, 255)
 back_colour = (0, 170, 170)
 
 message = "Hello, World!"
-size_x, size_y = draw.textsize(message, font)
+bbox = draw.textbbox((0, 0), message, font=font)
+size_x, size_y = bbox[2] - bbox[0], bbox[3] - bbox[1]
 
 # Calculate text position
 x = (WIDTH - size_x) / 2

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -10,9 +10,9 @@ from datetime import timedelta
 
 import gpiodevice
 import ltr559
-import ST7735
+import st7735
 import yaml
-from fonts.ttf import RobotoMedium as UserFont
+from font_roboto import RobotoMedium as UserFont
 from gpiod import LineSettings
 from gpiod.line import Bias, Edge
 from PIL import Image, ImageDraw, ImageFont
@@ -1022,7 +1022,7 @@ def main():
 
 
     # Set up the ST7735 SPI Display
-    display = ST7735.ST7735(
+    display = st7735.ST7735(
         port=0, cs=1, dc=9, backlight=12, rotation=270, spi_speed_hz=80000000
     )
     display.begin()

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -90,7 +90,8 @@ class View:
         if position not in ["A", "B", "X", "Y"]:
             raise ValueError(f"Invalid label position {position}")
 
-        text_w, text_h = self._draw.textsize(text, font=self.font)
+        bbox = self._draw.textbbox((0, 0), text, font=self.font)
+        text_w, text_h = bbox[2] - bbox[0], bbox[3] - bbox[1]
         text_h = 11
         text_w += margin * 2
         text_h += margin * 2
@@ -143,7 +144,7 @@ class View:
 
                 while (
                     len(words) > 0
-                    and font.getsize(" ".join(line + [words[0]]))[0] <= width
+                    and font.getlength(" ".join(line + [words[0]])) <= width
                 ):
                     line.append(words.pop(0))
 
@@ -161,7 +162,7 @@ class View:
                 bounds = [x2, y, x1, y + len(lines) * line_height]
 
                 for line in lines:
-                    line_width = font.getsize(line)[0]
+                    line_width = font.getlength(line)
                     x = int(x1 + (width / 2) - (line_width / 2))
                     bounds[0] = min(bounds[0], x)
                     bounds[2] = max(bounds[2], x + line_width)
@@ -222,7 +223,8 @@ class MainView(View):
         self.icon(icon_channel, (x, label_y), (200, 200, 200) if active else (64, 64, 64))
 
         # TODO: replace number text with graphic
-        tw, th = self.font.getsize(str(channel.channel))
+        bbox = self.font.getbbox(str(channel.channel))
+        tw = bbox[2] - bbox[0]
         self._draw.text(
             (x + int(math.ceil(8 - (tw / 2.0))), label_y + 1),
             str(channel.channel),
@@ -479,7 +481,8 @@ class DetailView(ChannelView):
 
         self.icon(icon_channel, (label_x, label_y), (200, 200, 200))
 
-        tw, th = self.font.getsize(str(self.channel.channel))
+        bbox = self.font.getbbox(str(self.channel.channel))
+        tw = bbox[2] - bbox[0]
         self._draw.text(
             (label_x + int(math.ceil(8 - (tw / 2.0))), label_y + 1),
             str(self.channel.channel),

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -2,20 +2,19 @@
 import logging
 import math
 import pathlib
+import select
 import sys
 import threading
 import time
-
-import select
 from datetime import timedelta
 
 import gpiodevice
 import ltr559
 import ST7735
 import yaml
+from fonts.ttf import RobotoMedium as UserFont
 from gpiod import LineSettings
 from gpiod.line import Bias, Edge
-from fonts.ttf import RobotoMedium as UserFont
 from PIL import Image, ImageDraw, ImageFont
 
 from grow import Piezo

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -6,10 +6,15 @@ import sys
 import threading
 import time
 
+import select
+from datetime import timedelta
+
+import gpiodevice
 import ltr559
-import RPi.GPIO as GPIO
 import ST7735
 import yaml
+from gpiod import LineSettings
+from gpiod.line import Bias, Edge
 from fonts.ttf import RobotoMedium as UserFont
 from PIL import Image, ImageDraw, ImageFont
 
@@ -1044,12 +1049,32 @@ def main():
 
     config = Config()
 
-    GPIO.setmode(GPIO.BCM)
-    GPIO.setwarnings(False)
-    GPIO.setup(BUTTONS, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-
+    # Set up buttons using gpiod
+    button_lines = []
     for pin in BUTTONS:
-        GPIO.add_event_detect(pin, GPIO.FALLING, handle_button, bouncetime=200)
+        line, offset = gpiodevice.get_pin(pin, f"grow-button-{pin}", LineSettings(
+            edge_detection=Edge.FALLING, bias=Bias.PULL_UP, debounce_period=timedelta(milliseconds=200)
+        ))
+        button_lines.append((line, offset, pin))
+
+    # Start button polling thread
+    button_poll_event = threading.Event()
+
+    def button_poll_thread():
+        poll = select.poll()
+        for line, offset, pin in button_lines:
+            poll.register(line.fd, select.POLLIN)
+        fd_to_pin = {line.fd: (line, pin) for line, offset, pin in button_lines}
+        while not button_poll_event.is_set():
+            events = poll.poll(100)  # 100ms timeout
+            for fd, event in events:
+                if event & select.POLLIN:
+                    line, pin = fd_to_pin[fd]
+                    line.read_edge_events()  # Clear the events
+                    handle_button(pin)
+
+    button_thread = threading.Thread(target=button_poll_thread, daemon=True)
+    button_thread.start()
 
     config.load()
 

--- a/examples/settings.yml
+++ b/examples/settings.yml
@@ -5,6 +5,7 @@ channel1:
   pump_speed: 0.5
   pump_time: 0.5
   warn_level: 0.2
+  water_level: 0.5
   watering_delay: 60
   wet_point: 3
 channel2:
@@ -14,6 +15,7 @@ channel2:
   pump_speed: 0.5
   pump_time: 0.5
   warn_level: 0.5
+  water_level: 0.5
   watering_delay: 60
   wet_point: 3
 channel3:
@@ -23,10 +25,11 @@ channel3:
   pump_speed: 0.5
   pump_time: 0.5
   warn_level: 0.4
+  water_level: 0.5
   watering_delay: 60
   wet_point: 3
 general:
   alarm_enable: true
   alarm_interval: 2
-  light_level_low: 4.0
   black_screen_when_light_low: false
+  light_level_low: 4.0

--- a/grow/__init__.py
+++ b/grow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.2'
+__version__ = '0.0.4'
 
 import atexit
 import threading

--- a/grow/moisture.py
+++ b/grow/moisture.py
@@ -1,6 +1,13 @@
 import time
+import select
+import threading
+from datetime import timedelta
+import atexit
 
-import RPi.GPIO as GPIO
+import gpiodevice
+from gpiod import LineSettings
+from gpiod.line import Edge, Bias
+
 
 MOISTURE_1_PIN = 23
 MOISTURE_2_PIN = 8
@@ -25,45 +32,54 @@ class Moisture(object):
         """
         self._gpio_pin = [MOISTURE_1_PIN, MOISTURE_2_PIN, MOISTURE_3_PIN, MOISTURE_INT_PIN][channel - 1]
 
-        GPIO.setwarnings(False)
-        GPIO.setmode(GPIO.BCM)
-        GPIO.setup(self._gpio_pin, GPIO.IN)
-
         self._count = 0
         self._reading = 0
         self._history = []
         self._history_length = 200
-        self._last_pulse = time.time()
         self._new_data = False
         self._wet_point = wet_point if wet_point is not None else 0.7
         self._dry_point = dry_point if dry_point is not None else 27.6
-        self._time_last_reading = time.time()
+
+        self._last_reading = 0
+
+        self._int, self._offset = gpiodevice.get_pin(self._gpio_pin, f"grow-m-ch{channel}", LineSettings(
+            edge_detection=Edge.RISING, bias=Bias.PULL_DOWN, debounce_period=timedelta(milliseconds=10)
+        ))
+
+        self._poll_thread_event = threading.Event()
+        self._poll_thread = threading.Thread(target=self._thread_poll)
+        self._poll_thread.start()
+
+        atexit.register(self._thread_stop)
+
+    def __del__(self):
+        self._thread_stop()
+
+    def _thread_stop(self):
+        self._poll_thread_event.set()
+        self._poll_thread.join()
+
+    def _thread_poll(self):
+        poll = select.poll()
         try:
-            GPIO.add_event_detect(self._gpio_pin, GPIO.RISING, callback=self._event_handler, bouncetime=1)
-        except RuntimeError as e:
-            if self._gpio_pin == 8:
-                raise RuntimeError("""Unable to set up edge detection on BCM8.
+            poll.register(self._int.fd, select.POLLIN)
+        except TypeError:
+            return
+        while not self._poll_thread_event.wait(1.0):
+            if not poll.poll(0):
+                # No pulses in 1s, this is not a valid reading
+                continue
 
-Please ensure you add the following to /boot/config.txt and reboot:
-
-dtoverlay=spi0-cs,cs0_pin=14 # Re-assign CS0 from BCM 8 so that Grow can use it
-
-""")
-            else:
-                raise e
-
-        self._time_start = time.time()
-
-    def _event_handler(self, pin):
-        self._count += 1
-        self._last_pulse = time.time()
-        if self._time_elapsed >= 1.0:
-            self._reading = self._count / self._time_elapsed
+            # We got pulses, since we waited for 1s we can be relatively
+            # sure the number of pulses is approximately the sensor frequency
+            events = self._int.read_edge_events()
+            self._last_reading = time.time()
+            self._reading = len(events)  # Pulse frequency
             self._history.insert(0, self._reading)
             self._history = self._history[:self._history_length]
-            self._count = 0
-            self._time_last_reading = time.time()
             self._new_data = True
+
+        poll.unregister(self._int.fd)
 
     @property
     def history(self):
@@ -75,10 +91,6 @@ dtoverlay=spi0-cs,cs0_pin=14 # Re-assign CS0 from BCM 8 so that Grow can use it
             history.append(max(0.0, min(1.0, saturation)))
 
         return history
-
-    @property
-    def _time_elapsed(self):
-        return time.time() - self._time_last_reading
 
     def set_wet_point(self, value=None):
         """Set the sensor wet point.
@@ -123,7 +135,7 @@ dtoverlay=spi0-cs,cs0_pin=14 # Re-assign CS0 from BCM 8 so that Grow can use it
     @property
     def active(self):
         """Check if the moisture sensor is producing a valid reading."""
-        return (time.time() - self._last_pulse) < 1.0 and self._reading > 0 and self._reading < 28
+        return (time.time() - self._last_reading) <= 1.0 and self._reading > 0 and self._reading < 28
 
     @property
     def new_data(self):

--- a/grow/moisture.py
+++ b/grow/moisture.py
@@ -55,6 +55,8 @@ class Moisture:
         self._thread_stop()
 
     def _thread_stop(self):
+        if not hasattr(self, "_poll_thread_event"):
+            return  # Constructor failed before thread was created
         self._poll_thread_event.set()
         self._poll_thread.join()
 

--- a/grow/moisture.py
+++ b/grow/moisture.py
@@ -1,13 +1,12 @@
-import time
+import atexit
 import select
 import threading
+import time
 from datetime import timedelta
-import atexit
 
 import gpiodevice
 from gpiod import LineSettings
-from gpiod.line import Edge, Bias
-
+from gpiod.line import Bias, Edge
 
 MOISTURE_1_PIN = 23
 MOISTURE_2_PIN = 8

--- a/grow/moisture.py
+++ b/grow/moisture.py
@@ -14,7 +14,7 @@ MOISTURE_3_PIN = 25
 MOISTURE_INT_PIN = 4
 
 
-class Moisture(object):
+class Moisture:
     """Grow moisture sensor driver."""
 
     def __init__(self, channel=1, wet_point=None, dry_point=None):

--- a/grow/pump.py
+++ b/grow/pump.py
@@ -13,7 +13,7 @@ PUMP_PWM_FREQ = 10000
 PUMP_MAX_DUTY = 0.9
 
 PLATFORMS = {
-    "Raspberry Pi 5": {"pump1": ("PIN11", pwm.OUTL), "pump2": ("PIN12", pwm.OUTL), "pump3": ("PIN15", pwm.OUTL)},
+    "Raspberry Pi 5": {"pump1": ("PIN11", pwm.OUTL), "pump2": ("PIN13", pwm.OUTL), "pump3": ("PIN15", pwm.OUTL)},
     "Raspberry Pi 4": {"pump1": ("GPIO17", pwm.OUTL), "pump2": ("GPIO27", pwm.OUTL), "pump3": ("GPIO22", pwm.OUTL)},
 }
 

--- a/grow/pump.py
+++ b/grow/pump.py
@@ -21,7 +21,7 @@ PLATFORMS = {
 global_lock = threading.Lock()
 
 
-class Pump(object):
+class Pump:
     """Grow pump driver."""
 
     PINS = None
@@ -47,6 +47,7 @@ class Pump(object):
         atexit.register(pwm.PWM.stop_thread)
 
         self._timeout = None
+        self._speed = 0
 
     def set_speed(self, speed):
         """Set pump speed (PWM duty cycle)."""

--- a/grow/pwm.py
+++ b/grow/pwm.py
@@ -1,0 +1,106 @@
+import time
+from threading import Thread
+
+import gpiod
+import gpiodevice
+from gpiod.line import Direction, Value
+
+OUTL = gpiod.LineSettings(direction=Direction.OUTPUT, output_value=Value.INACTIVE)
+
+
+class PWM:
+    _pwms: list = []
+    _t_pwm: Thread = None
+    _pwm_running: bool = False
+
+    @staticmethod
+    def start_thread():
+        if PWM._t_pwm is None:
+            PWM._pwm_running = True
+            PWM._t_pwm = Thread(target=PWM._run)
+            PWM._t_pwm.start()
+
+    @staticmethod
+    def stop_thread():
+        if PWM._t_pwm is not None:
+            PWM._pwm_running = False
+            PWM._t_pwm.join()
+            PWM._t_pwm = None
+
+    @staticmethod
+    def _add(pwm):
+        PWM._pwms.append(pwm)
+
+    @staticmethod
+    def _remove(pwm):
+        index = PWM._pwms.index(pwm)
+        del PWM._pwms[index]
+        if len(PWM._pwms) == 0:
+            PWM.stop_thread()
+
+    @staticmethod
+    def _run():
+        while PWM._pwm_running:
+            PWM.run()
+
+    @staticmethod
+    def run():
+        for pwm in PWM._pwms:
+            pwm.next(time.time())
+
+    def __init__(self, pin, frequency=0, duty_cycle=0, lines=None, offset=None):
+        self.duty_cycle = 0
+        self.frequency = 0
+        self.duty_period = 0
+        self.period = 0
+        self.running = False
+        self.time_start = None
+        self.state = Value.ACTIVE
+
+        self.set_frequency(frequency)
+        self.set_duty_cycle(duty_cycle)
+
+        if isinstance(pin, tuple):
+            self.lines, self.offset = pin
+        else:
+            self.lines, self.offset = gpiodevice.get_pin(pin, "PWM", OUTL)
+
+        PWM._add(self)
+
+    def set_frequency(self, frequency):
+        if frequency == 0:
+            return
+        self.frequency = frequency
+        self.period = 1.0 / frequency
+        self.duty_period = self.duty_cycle * self.period
+
+    def set_duty_cycle(self, duty_cycle):
+        self.duty_cycle = duty_cycle
+        self.duty_period = self.duty_cycle * self.period
+
+    def start(self, duty_cycle=None, frequency=None, start_time=None):
+        if duty_cycle is not None:
+            self.set_duty_cycle(duty_cycle)
+
+        if frequency is not None:
+            self.set_frequency(frequency)
+
+        self.time_start = time.time() if start_time is None else start_time
+
+        self.running = True
+
+    def next(self, t):
+        if not self.running:
+            return
+        d = t - self.time_start
+        d %= self.period
+        new_state = Value.ACTIVE if d < self.duty_period else Value.INACTIVE
+        if new_state != self.state:
+            self.lines.set_value(self.offset, new_state)
+            self.state = new_state
+
+    def stop(self):
+        self.running = False
+
+    def __del__(self):
+        PWM._remove(self)

--- a/grow/pwm.py
+++ b/grow/pwm.py
@@ -25,6 +25,7 @@ class PWM:
             PWM._t_pwm_event.set()
             PWM._t_pwm.join()
             PWM._t_pwm = None
+            PWM._t_pwm_event.clear()
 
     @staticmethod
     def _add(pwm):
@@ -32,7 +33,10 @@ class PWM:
 
     @staticmethod
     def _remove(pwm):
-        index = PWM._pwms.index(pwm)
+        try:
+            index = PWM._pwms.index(pwm)
+        except ValueError:
+            return  # Instance was never added (constructor failed)
         PWM._pwms.pop(index)
         if len(PWM._pwms) == 0:
             PWM.stop_thread()

--- a/grow/pwm.py
+++ b/grow/pwm.py
@@ -95,6 +95,8 @@ class PWM:
     def next(self, t):
         if not self.running:
             return
+        if self.period == 0:
+            return  # Avoid ZeroDivisionError when frequency is not set
         d = t - self.time_start
         d %= self.period
         new_state = Value.ACTIVE if d < self.duty_period else Value.INACTIVE

--- a/grow/pwm.py
+++ b/grow/pwm.py
@@ -1,5 +1,5 @@
 import time
-from threading import Thread
+from threading import Event, Thread
 
 import gpiod
 import gpiodevice
@@ -11,19 +11,18 @@ OUTL = gpiod.LineSettings(direction=Direction.OUTPUT, output_value=Value.INACTIV
 class PWM:
     _pwms: list = []
     _t_pwm: Thread = None
-    _pwm_running: bool = False
+    _t_pwm_event: Event = Event()
 
     @staticmethod
     def start_thread():
         if PWM._t_pwm is None:
-            PWM._pwm_running = True
             PWM._t_pwm = Thread(target=PWM._run)
             PWM._t_pwm.start()
 
     @staticmethod
     def stop_thread():
         if PWM._t_pwm is not None:
-            PWM._pwm_running = False
+            PWM._t_pwm_event.set()
             PWM._t_pwm.join()
             PWM._t_pwm = None
 
@@ -34,13 +33,13 @@ class PWM:
     @staticmethod
     def _remove(pwm):
         index = PWM._pwms.index(pwm)
-        del PWM._pwms[index]
+        PWM._pwms.pop(index)
         if len(PWM._pwms) == 0:
             PWM.stop_thread()
 
     @staticmethod
     def _run():
-        while PWM._pwm_running:
+        while not PWM._t_pwm_event.is_set():
             PWM.run()
 
     @staticmethod

--- a/grow/pwm.py
+++ b/grow/pwm.py
@@ -45,6 +45,7 @@ class PWM:
     def _run():
         while not PWM._t_pwm_event.is_set():
             PWM.run()
+            time.sleep(0.001)  # 1ms sleep to reduce CPU usage
 
     @staticmethod
     def run():
@@ -58,7 +59,7 @@ class PWM:
         self.period = 0
         self.running = False
         self.time_start = None
-        self.state = Value.ACTIVE
+        self.state = Value.INACTIVE  # Match GPIO initial output_value
 
         self.set_frequency(frequency)
         self.set_duty_cycle(duty_cycle)
@@ -106,6 +107,8 @@ class PWM:
 
     def stop(self):
         self.running = False
+        self.lines.set_value(self.offset, Value.INACTIVE)
+        self.state = Value.INACTIVE
 
     def __del__(self):
         PWM._remove(self)

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ DATESTAMP=$(date "+%Y-%m-%d-%H-%M-%S")
 CONFIG_BACKUP=false
 APT_HAS_UPDATED=false
 RESOURCES_TOP_DIR=$HOME/Pimoroni
-VENV_BASH_SNIPPET=$RESOURCES_DIR/auto_venv.sh
+VENV_BASH_SNIPPET=$RESOURCES_TOP_DIR/auto_venv.sh
 VENV_DIR=$HOME/.virtualenvs/pimoroni
 WD=$(pwd)
 USAGE="./install.sh (--unstable)"
@@ -77,7 +77,7 @@ find_config() {
 venv_bash_snippet() {
 	if [ ! -f "$VENV_BASH_SNIPPET" ]; then
 		cat << EOF > "$VENV_BASH_SNIPPET"
-# Add `source $RESOURCES_DIR/auto_venv.sh` to your ~/.bashrc to activate
+# Add `source "$VENV_BASH_SNIPPET"` to your ~/.bashrc to activate
 # the Pimoroni virtual environment automagically!
 VENV_DIR="$VENV_DIR"
 if [ ! -f \$VENV_DIR/bin/activate ]; then

--- a/install.sh
+++ b/install.sh
@@ -199,7 +199,7 @@ printf "%s Python Library: Installer\n\n" $LIBRARY_NAME
 
 inform "Checking Dependencies. Please wait..."
 
-pip_pkg_install toml
+pip_pkg_install toml setuptools
 
 CONFIG_VARS=`$PYTHON - <<EOF
 import toml

--- a/install.sh
+++ b/install.sh
@@ -119,9 +119,9 @@ function do_config_backup {
 		CONFIG_BACKUP=true
 		FILENAME="config.preinstall-$LIBRARY_NAME-$DATESTAMP.txt"
 		inform "Backing up $CONFIG_DIR/$CONFIG_FILE to $CONFIG_DIR/$FILENAME\n"
-		sudo cp "$CONFIG_DIR/$CONFIG_FILE $CONFIG_DIR/$FILENAME"
+		sudo cp "$CONFIG_DIR/$CONFIG_FILE" "$CONFIG_DIR/$FILENAME"
 		mkdir -p "$RESOURCES_TOP_DIR/config-backups/"
-		cp $CONFIG_DIR/$CONFIG_FILE "$RESOURCES_TOP_DIR/config-backups/$FILENAME"
+		cp "$CONFIG_DIR/$CONFIG_FILE" "$RESOURCES_TOP_DIR/config-backups/$FILENAME"
 		if [ -f "$UNINSTALLER" ]; then
 			echo "cp $RESOURCES_TOP_DIR/config-backups/$FILENAME $CONFIG_DIR/$CONFIG_FILE" >> "$UNINSTALLER"
 		fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,10 @@ classifiers = [
     "Topic :: System :: Hardware",
 ]
 dependencies = [
-	"ltr559",
-	"st7735>=0.0.5",
+    "gpiodevice",
+    "gpiod>=2.1.3",
+	"ltr559>=1.0.0",
+	"st7735>=1.0.0",
 	"pyyaml",
 	"fonts",
 	"font-roboto"
@@ -121,5 +123,11 @@ ignore = [
 
 [tool.pimoroni]
 apt_packages = []
-configtxt = []
-commands = []
+configtxt = [
+    "dtoverlay=spi0-cs,cs0_pin=14" # Re-assign CS0 from BCM 8 so that Grow can use it
+]
+commands = [
+    "printf \"Setting up i2c and SPI..\\n\"",
+	"sudo raspi-config nonint do_spi 0",
+	"sudo raspi-config nonint do_i2c 0"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "growhat"
 dynamic = ["version", "readme"]
 description = "Grow HAT Mini. A plant valet add-on for the Raspberry Pi"
 license = {file = "LICENSE"}
-requires-python = ">= 3.7"
+requires-python = ">= 3.9"
 authors = [
     { name = "Philip Howard", email = "phil@pimoroni.com" },
     { name = "Paul Beech", email = "paul@pimoroni.com" },
@@ -25,11 +25,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,31 +18,20 @@ class SMBusFakeDevice(MockSMBus):
 @pytest.fixture(scope='function', autouse=True)
 def cleanup():
     yield None
-    try:
-        del sys.modules['grow']
-    except KeyError:
-        pass
-    try:
-        del sys.modules['grow.moisture']
-    except KeyError:
-        pass
-    try:
-        del sys.modules['grow.pump']
-    except KeyError:
-        pass
+    for module in ['grow', 'grow.moisture', 'grow.pump']:
+        try:
+            del sys.modules[module]
+        except KeyError:
+            continue
 
 
 @pytest.fixture(scope='function', autouse=False)
 def GPIO():
-    """Mock RPi.GPIO module."""
-    GPIO = mock.MagicMock()
-    # Fudge for Python < 37 (possibly earlier)
-    sys.modules['RPi'] = mock.Mock()
-    sys.modules['RPi'].GPIO = GPIO
-    sys.modules['RPi.GPIO'] = GPIO
-    yield GPIO
-    del sys.modules['RPi']
-    del sys.modules['RPi.GPIO']
+    """Mock gpiod module."""
+    gpiod = mock.MagicMock()
+    sys.modules['gpiod'] = gpiod
+    yield gpiod
+    del sys.modules['gpiod']
 
 
 @pytest.fixture(scope='function', autouse=False)
@@ -55,13 +44,13 @@ def spidev():
 
 
 @pytest.fixture(scope='function', autouse=False)
-def smbus():
-    """Mock smbus module."""
-    smbus = mock.MagicMock()
-    smbus.SMBus = SMBusFakeDevice
-    sys.modules['smbus'] = smbus
-    yield smbus
-    del sys.modules['smbus']
+def smbus2():
+    """Mock smbus2 module."""
+    smbus2 = mock.MagicMock()
+    smbus2.SMBus = SMBusFakeDevice
+    sys.modules['smbus2'] = smbus2
+    yield smbus2
+    del sys.modules['smbus2']
 
 
 @pytest.fixture(scope='function', autouse=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,8 @@ These allow the mocking of various Python modules
 that might otherwise have runtime side-effects.
 """
 import sys
+from unittest import mock
 
-import mock
 import pytest
 from i2cdevice import MockSMBus
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,12 +26,24 @@ def cleanup():
 
 
 @pytest.fixture(scope='function', autouse=False)
-def GPIO():
+def gpiod():
     """Mock gpiod module."""
-    gpiod = mock.MagicMock()
-    sys.modules['gpiod'] = gpiod
-    yield gpiod
-    del sys.modules['gpiod']
+    sys.modules["gpiod"] = mock.Mock()
+    sys.modules["gpiod.line"] = mock.Mock()
+    yield sys.modules["gpiod"]
+    del sys.modules["gpiod.line"]
+    del sys.modules["gpiod"]
+
+
+@pytest.fixture(scope="function", autouse=False)
+def gpiodevice():
+    gpiodevice = mock.Mock()
+    gpiodevice.get_pins_for_platform.return_value = [(mock.Mock(), 0), (mock.Mock(), 0), (mock.Mock(), 0)]
+    gpiodevice.get_pin.return_value = (mock.Mock(), 0)
+
+    sys.modules["gpiodevice"] = gpiodevice
+    yield gpiodevice
+    del sys.modules["gpiodevice"]
 
 
 @pytest.fixture(scope='function', autouse=False)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,7 +1,7 @@
 import time
 
 
-def test_pumps_actually_stop(GPIO, smbus):
+def test_pumps_actually_stop(gpiod, smbus2):
     from grow.pump import Pump
 
     ch1 = Pump(channel=1)
@@ -11,7 +11,7 @@ def test_pumps_actually_stop(GPIO, smbus):
     assert ch1.get_speed() == 0
 
 
-def test_pumps_are_mutually_exclusive(GPIO, smbus):
+def test_pumps_are_mutually_exclusive(gpiod, smbus2):
     from grow.pump import Pump, global_lock
 
     ch1 = Pump(channel=1)
@@ -29,7 +29,7 @@ def test_pumps_are_mutually_exclusive(GPIO, smbus):
     assert ch3.dose(speed=0.5, blocking=False) is False
 
 
-def test_pumps_run_sequentially(GPIO, smbus):
+def test_pumps_run_sequentially(gpiod, smbus2):
     from grow.pump import Pump, global_lock
 
     ch1 = Pump(channel=1)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,8 +1,9 @@
 import time
 
 
-def test_pumps_actually_stop(gpiod, smbus2):
+def test_pumps_actually_stop(gpiod, gpiodevice, smbus2):
     from grow.pump import Pump
+    from grow.pwm import PWM
 
     ch1 = Pump(channel=1)
 
@@ -10,9 +11,13 @@ def test_pumps_actually_stop(gpiod, smbus2):
     time.sleep(0.1)
     assert ch1.get_speed() == 0
 
+    PWM.stop_thread()
 
-def test_pumps_are_mutually_exclusive(gpiod, smbus2):
+
+
+def test_pumps_are_mutually_exclusive(gpiod, gpiodevice, smbus2):
     from grow.pump import Pump, global_lock
+    from grow.pwm import PWM
 
     ch1 = Pump(channel=1)
     ch2 = Pump(channel=2)
@@ -28,9 +33,13 @@ def test_pumps_are_mutually_exclusive(gpiod, smbus2):
     assert ch3.dose(speed=0.5) is False
     assert ch3.dose(speed=0.5, blocking=False) is False
 
+    PWM.stop_thread()
 
-def test_pumps_run_sequentially(gpiod, smbus2):
+
+
+def test_pumps_run_sequentially(gpiod, gpiodevice, smbus2):
     from grow.pump import Pump, global_lock
+    from grow.pwm import PWM
 
     ch1 = Pump(channel=1)
     ch2 = Pump(channel=2)
@@ -45,3 +54,5 @@ def test_pumps_run_sequentially(gpiod, smbus2):
     assert ch3.dose(speed=0.5, timeout=0.1, blocking=False) is True
     assert global_lock.locked() is True
     time.sleep(0.3)
+
+    PWM.stop_thread()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,7 +1,7 @@
 import mock
 
 
-def test_moisture_setup(GPIO, smbus):
+def test_moisture_setup(gpiod, smbus2):
     from grow.moisture import Moisture
 
     ch1 = Moisture(channel=1)
@@ -15,7 +15,7 @@ def test_moisture_setup(GPIO, smbus):
     ])
 
 
-def test_moisture_read(GPIO, smbus):
+def test_moisture_read(gpiod, smbus2):
     from grow.moisture import Moisture
 
     assert Moisture(channel=1).saturation == 1.0
@@ -27,7 +27,7 @@ def test_moisture_read(GPIO, smbus):
     assert Moisture(channel=3).moisture == 0
 
 
-def test_pump_setup(GPIO, smbus):
+def test_pump_setup(gpiod, smbus2):
     from grow.pump import PUMP_PWM_FREQ, Pump
 
     ch1 = Pump(channel=1)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,21 +1,16 @@
 import mock
 
 
-def test_moisture_setup(gpiod, smbus2):
+def test_moisture_setup(gpiod, gpiodevice, smbus2):
     from grow.moisture import Moisture
+    from datetime import timedelta
 
     ch1 = Moisture(channel=1)
     ch2 = Moisture(channel=2)
     ch3 = Moisture(channel=3)
 
-    GPIO.setup.assert_has_calls([
-        mock.call(ch1._gpio_pin, GPIO.IN),
-        mock.call(ch2._gpio_pin, GPIO.IN),
-        mock.call(ch3._gpio_pin, GPIO.IN)
-    ])
 
-
-def test_moisture_read(gpiod, smbus2):
+def test_moisture_read(gpiod, gpiodevice, smbus2):
     from grow.moisture import Moisture
 
     assert Moisture(channel=1).saturation == 1.0
@@ -27,24 +22,14 @@ def test_moisture_read(gpiod, smbus2):
     assert Moisture(channel=3).moisture == 0
 
 
-def test_pump_setup(gpiod, smbus2):
+def test_pump_setup(gpiod, gpiodevice, smbus2):
     from grow.pump import PUMP_PWM_FREQ, Pump
+    from grow.pwm import PWM
 
     ch1 = Pump(channel=1)
     ch2 = Pump(channel=2)
     ch3 = Pump(channel=3)
 
-    GPIO.setup.assert_has_calls([
-        mock.call(ch1._gpio_pin, GPIO.OUT, initial=GPIO.LOW),
-        mock.call(ch2._gpio_pin, GPIO.OUT, initial=GPIO.LOW),
-        mock.call(ch3._gpio_pin, GPIO.OUT, initial=GPIO.LOW)
-    ])
+    # Threads. Not even once.
+    PWM.stop_thread()
 
-    GPIO.PWM.assert_has_calls([
-        mock.call(ch1._gpio_pin, PUMP_PWM_FREQ),
-        mock.call().start(0),
-        mock.call(ch2._gpio_pin, PUMP_PWM_FREQ),
-        mock.call().start(0),
-        mock.call(ch3._gpio_pin, PUMP_PWM_FREQ),
-        mock.call().start(0)
-    ])

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,14 +1,9 @@
-import mock
-
-
 def test_moisture_setup(gpiod, gpiodevice, smbus2):
-    from datetime import timedelta
-
     from grow.moisture import Moisture
 
-    ch1 = Moisture(channel=1)
-    ch2 = Moisture(channel=2)
-    ch3 = Moisture(channel=3)
+    _ = Moisture(channel=1)
+    _ = Moisture(channel=2)
+    _ = Moisture(channel=3)
 
 
 def test_moisture_read(gpiod, gpiodevice, smbus2):
@@ -24,12 +19,12 @@ def test_moisture_read(gpiod, gpiodevice, smbus2):
 
 
 def test_pump_setup(gpiod, gpiodevice, smbus2):
-    from grow.pump import PUMP_PWM_FREQ, Pump
+    from grow.pump import Pump
     from grow.pwm import PWM
 
-    ch1 = Pump(channel=1)
-    ch2 = Pump(channel=2)
-    ch3 = Pump(channel=3)
+    _ = Pump(channel=1)
+    _ = Pump(channel=2)
+    _ = Pump(channel=3)
 
     # Threads. Not even once.
     PWM.stop_thread()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2,8 +2,9 @@ import mock
 
 
 def test_moisture_setup(gpiod, gpiodevice, smbus2):
-    from grow.moisture import Moisture
     from datetime import timedelta
+
+    from grow.moisture import Moisture
 
     ch1 = Moisture(channel=1)
     ch2 = Moisture(channel=2)

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
 	python -m build --no-isolation
 	python -m twine check dist/*
 	isort --check .
-	ruff .
+	ruff check .
 	codespell .
 deps =
 	check-manifest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py,qa
+envlist = py39,py310,py311,py312,qa
 skip_missing_interpreters = True
 isolated_build = true
 minversion = 4.0.0
@@ -9,7 +9,6 @@ commands =
 	coverage run -m pytest -v -r wsx
 	coverage report
 deps =
-	mock
 	pytest>=3.1
 	pytest-cov
 	build


### PR DESCRIPTION
## Summary

This PR modernizes the examples and fixes deprecation warnings to ensure compatibility with Python 3.12+ and modern Raspberry Pi OS.

## Changes

- **Migrate monitor.py from RPi.GPIO to gpiod** for button handling (Pi 5 compatible)
- **Update ST7735 import** to lowercase (\`st7735\`) to fix deprecation warning
- **Replace fonts.ttf with direct font_roboto import** to avoid pkg_resources deprecation (pkg_resources is slated for removal in setuptools 81+)
- **Add setuptools to install.sh** dependencies
- **Update documentation** (REFERENCE.md, CHANGELOG.md, README.md) with modern import examples

## Testing

Tested on Raspberry Pi 4 with Python 3.13 - monitor.py runs without deprecation warnings.