### PR TITLE
Updates for RPi.GPIO and Pillow to support Trixie

### DIFF
--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -8,9 +8,10 @@ import time
 
 import ltr559
 import RPi.GPIO as GPIO
-import ST7735
+import st7735 as ST7735
 import yaml
-from fonts.ttf import RobotoMedium as UserFont
+from importlib.resources import files
+UserFont = str(files("font_roboto").joinpath("files/Roboto-Medium.ttf"))
 from PIL import Image, ImageDraw, ImageFont
 
 from grow import Piezo

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -90,7 +90,7 @@ class View:
         if position not in ["A", "B", "X", "Y"]:
             raise ValueError(f"Invalid label position {position}")
 
-        text_w, text_h = self._draw.textsize(text, font=self.font)
+        _bbox = self.font.getbbox(text); text_w, text_h = _bbox[2] - _bbox[0], _bbox[3] - _bbox[1]
         text_h = 11
         text_w += margin * 2
         text_h += margin * 2
@@ -143,7 +143,7 @@ class View:
 
                 while (
                     len(words) > 0
-                    and font.getsize(" ".join(line + [words[0]]))[0] <= width
+                    and font.getbbox(" ".join(line + [words[0]]))[2] <= width
                 ):
                     line.append(words.pop(0))
 
@@ -161,7 +161,7 @@ class View:
                 bounds = [x2, y, x1, y + len(lines) * line_height]
 
                 for line in lines:
-                    line_width = font.getsize(line)[0]
+                    line_width = font.getbbox(line)[2]
                     x = int(x1 + (width / 2) - (line_width / 2))
                     bounds[0] = min(bounds[0], x)
                     bounds[2] = max(bounds[2], x + line_width)
@@ -222,7 +222,7 @@ class MainView(View):
         self.icon(icon_channel, (x, label_y), (200, 200, 200) if active else (64, 64, 64))
 
         # TODO: replace number text with graphic
-        tw, th = self.font.getsize(str(channel.channel))
+        _bbox = self.font.getbbox(str(channel.channel)); tw, th = _bbox[2] - _bbox[0], _bbox[3] - _bbox[1]
         self._draw.text(
             (x + int(math.ceil(8 - (tw / 2.0))), label_y + 1),
             str(channel.channel),
@@ -479,7 +479,7 @@ class DetailView(ChannelView):
 
         self.icon(icon_channel, (label_x, label_y), (200, 200, 200))
 
-        tw, th = self.font.getsize(str(self.channel.channel))
+        _bbox = self.font.getbbox(str(self.channel.channel)); tw, th = _bbox[2] - _bbox[0], _bbox[3] - _bbox[1]
         self._draw.text(
             (label_x + int(math.ceil(8 - (tw / 2.0))), label_y + 1),
             str(self.channel.channel),

--- a/grow/pump.py
+++ b/grow/pump.py
@@ -39,7 +39,7 @@ class Pump(object):
         atexit.register(self._stop)
 
     def _stop(self):
-        self._pwm.stop(0)
+        self._pwm.stop()
         GPIO.setup(self._gpio_pin, GPIO.IN)
 
     def set_speed(self, speed):


### PR DESCRIPTION
Update the monitor.py example to support recent versions of RPi.GPIO and Pillow.  I tested and confirmed this works on Trixie (Raspberry Pi OS 21 Apr 2026) with the latest versions of packages installed.

  * https://blog.geekfarm.org/pimoroni-grow-hat-mini.html

This patch is not enough to fix `curl -sSL https://get.pimoroni.com/grow | bash` on trixie, as there are some missing libraries.
